### PR TITLE
Add well section tests and retain-non-delimiter-periods

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -101,7 +101,7 @@ pub(crate) fn property(raw_str: &str, key: &str) -> HashMap<String, WellProp> {
     let mut prop_hash: HashMap<String, WellProp> = HashMap::new();
 
     lines.into_iter().for_each(|line| {
-        let root = DOT_IN_SPACES.replace_all(line, "   none   ");
+        let root = DOT_IN_SPACES.replace(line, "   none   ");
         let title = DOT_OR_SPACES
             .splitn(&root, 2)
             .nth(0)
@@ -215,4 +215,32 @@ mod test {
         );
         assert_eq!(&WellProp::new("m", "", ""), result.get("Gamma").unwrap());
     }
+
+    #[test]
+    fn test_() {
+        let test = "~Well
+	STRT    .M              1670.0000                :START DEPTH
+	STOP    .M              1669.7500                :STOP DEPTH
+	STEP    .M              -0.1250                  :STEP
+	NULL    .               -999.25                  :NULL VALUE
+	COMP    .       ANY OIL COMPANY INC.             :COMPANY
+	WELL    .       ANY ET AL 12-34-12-34            :WELL
+	FLD     .       WILDCAT                          :FIELD
+	LOC     .       12-34-12-34W5M                   :LOCATION
+	PROV    .       ALBERTA                          :PROVINCE
+	SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+	DATE    .       13-DEC-86                        :LOG DATE
+	UWI     .       100123401234W500                 :UNIQUE WELL ID
+    ";
+		let result = property(test, "~W");
+		assert_eq!(
+			&WellProp::new("", "COMPANY", "ANY OIL COMPANY INC."),
+			result.get("COMP").unwrap()
+		);
+		assert_eq!(
+			&WellProp::new("", "SERVICE COMPANY", "ANY LOGGING COMPANY INC."),
+			result.get("SRVC").unwrap()
+		);
+	}
 }
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use lasrs::Las;
+use lasrs::{Las, WellProp};
 
 #[test]
 fn version_test() {
@@ -121,4 +121,58 @@ fn csv_test() {
     ];
     assert_eq!(expected.join("\n").to_string(), result);
     fs::remove_file("example.csv").expect("Could not clean up after test");
+}
+
+#[test]
+fn well_section_test() {
+    let las = Las::new("./sample/example.las");
+    let well_section = las.well_info();
+    assert_eq!(
+    &WellProp::new("M", "START DEPTH", "1670.0000"),
+        well_section.get("STRT").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("M", "STOP DEPTH", "1669.7500"),
+        well_section.get("STOP").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("M", "STEP", "-0.1250"),
+        well_section.get("STEP").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "NULL VALUE", "-999.25"),
+        well_section.get("NULL").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "COMPANY", "ANY OIL COMPANY INC."),
+        well_section.get("COMP").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "WELL", "ANY ET AL 12-34-12-34"),
+        well_section.get("WELL").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "FIELD", "WILDCAT"),
+        well_section.get("FLD").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "LOCATION", "12-34-12-34W5M"),
+        well_section.get("LOC").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "PROVINCE", "ALBERTA"),
+        well_section.get("PROV").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "SERVICE COMPANY", "ANY LOGGING COMPANY INC."),
+        well_section.get("SRVC").unwrap()
+    );
+    assert_eq!(
+    &WellProp::new("", "LOG DATE", "13-DEC-86"),
+        well_section.get("DATE").unwrap()
+    );
+    assert_eq!(
+        &WellProp::new("", "UNIQUE WELL ID", "100123401234W500"),
+        well_section.get("UWI").unwrap()
+    );
 }


### PR DESCRIPTION
@iykekings,

This pull-request has the following changes:
- Add tests to utils.rs and integration_tests.rs.
- Change utils.rs 'root' to keep the '.' after the delimiter '.'.
  This is so that names with abbreviations ending in a '.' will keep
  their value. For example, the COMP value "ANY OIL COMPANY INC."
  would keep the period on the 'INC." abbreviation.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC

